### PR TITLE
Save the correct embeddings object

### DIFF
--- a/create_index.py
+++ b/create_index.py
@@ -34,4 +34,4 @@ docsearch = FAISS.from_texts(texts, embeddings)
 
 
 with open("gpt-4.pkl", 'wb') as f:
-    pickle.dump(embeddings, f)
+    pickle.dump(docsearch, f)


### PR DESCRIPTION
We were saving a wrong object to the pickle, due to which, the pickle file was empty